### PR TITLE
fix(sec): upgrade commons-codec:commons-codec to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<protostuff.version>1.5.0</protostuff.version>
 		<logback.version>1.2.0</logback.version>
 		<hystrix.version>1.5.18</hystrix.version>
-		<commons-codec.version>1.10</commons-codec.version>
+		<commons-codec.version>1.13</commons-codec.version>
 		<commons-lang3.version>3.4</commons-lang3.version>
 		<javax.servlet-api.version>3.1.0</javax.servlet-api.version>
 		<guava.version>18.0</guava.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-codec:commons-codec 1.10
- [MPS-2022-11853](https://www.oscs1024.com/hd/MPS-2022-11853)


### What did I do？
Upgrade commons-codec:commons-codec from 1.10 to 1.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS